### PR TITLE
chore: add pre-commit and formatting tools

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,6 +109,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run pre-commit
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files
       - name: Install Playwright
         working-directory: ${{ env.WORKDIR }}
         run: python -m playwright install --with-deps ${{ matrix.browser }}
@@ -188,6 +193,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files
       - name: Install Playwright
         run: python -m playwright install --with-deps ${{ matrix.browser }}
       - name: Run role tests (skip if missing creds)
@@ -255,6 +264,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files
       - name: Install Playwright
         run: python -m playwright install --with-deps ${{ matrix.browser }}
       - name: Run write tests
@@ -311,6 +324,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files
       - name: Install Playwright
         run: python -m playwright install --with-deps chromium
       - name: Discover URLs and generate tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: pytest-collect-only
+        name: pytest --collect-only
+        entry: pytest --collect-only
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ cp .env.example .env
 
 # 4) (Tùy chọn) Build Docker image
 make build
+
+# 5) Thiết lập pre-commit (format + lint)
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
 ```
 
 > **Ghi chú về config:**
@@ -233,6 +238,7 @@ pytest -vv tests --browser=chromium --browser=webkit --browser=firefox
 ## 9) CI/CD (GitHub Actions)
 
 Workflow mẫu nằm tại: `.github/workflows/e2e.yml`.
+Workflow này có bước `pre-commit run --all-files` để kiểm tra định dạng và lint trước khi chạy test.
 Khuyến nghị:
 
 * Job chính dùng **Chromium** (nhanh)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+line-length = 88
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503"]
+exclude = [
+    ".git",
+    "__pycache__",
+    "build",
+    "dist",
+    "report",
+    "test-results",
+]


### PR DESCRIPTION
## Summary
- configure black and flake8 via pyproject
- add pre-commit with black, flake8 and pytest collect
- document pre-commit usage and run it in CI

## Testing
- `pre-commit run --all-files` *(failed: command not found)*
- `pip install pre-commit` *(failed: No matching distribution found)*
- `pytest --collect-only` *(failed: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68c7820d223483269d17654952689632